### PR TITLE
Fix for install_aws.ps1

### DIFF
--- a/cfn/setup-env-cfn-template.json
+++ b/cfn/setup-env-cfn-template.json
@@ -299,7 +299,7 @@
                     "mkdir -p /home/ec2-user/scripts/docker \n",
                     "chown ec2-user:ec2-user /home/ec2-user/scripts /home/ec2-user/scripts/setup /home/ec2-user/scripts/docker \n",
                     "chmod 755 /home/ec2-user/scripts \n",
-                    "pwsh -Command /tmp/install_aws.ps1 \n",
+                    "runuser -l ec2-user -c 'pwsh /tmp/install_aws.ps1' \n",
                     "cat >> /home/ec2-user/.bash_profile <<EOF\n",
                     "SETUP_PS1=\"/home/ec2-user/scripts/setup/setup.ps1\" \n",
                     "SETUP_PS_COMMAND=\"/home/ec2-user/scripts/setup/setup.ps1 ", "-appName ", { "Ref": "AWS::StackName" }, " -Region ", { "Ref" : "AWS::Region" }, " -kmsKeyId ", { "Fn::GetAtt": ["ParamEncryptionKey", "Arn"] }, " -azureADTenantName ", { "Ref" : "AzureADTennantName" }, "\" \n",


### PR DESCRIPTION
When the Powershell .Net core modules are installed it is done for "ec2-user" and the execution of the "install_aws.ps1" breaks when run as root.

*Issue #1 

*Description of changes: Modified the User Data script used by the instance at launch to run the Powershell script as the appropriate account.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
